### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,12 @@
         <repository>
             <id>maven.aksw.internal</id>
             <name>AKSW Internal Release Repository</name>
-            <url>http://maven.aksw.org/repository/internal/</url>
+            <url>https://maven.aksw.org/repository/internal/</url>
         </repository>
         <repository>
             <id>maven.aksw.snapshots</id>
             <name>University Leipzig, AKSW Maven2 Repository</name>
-            <url>http://maven.aksw.org/repository/snapshots</url>
+            <url>https://maven.aksw.org/repository/snapshots</url>
         </repository>
         <repository>
             <id>spring-releases</id>


### PR DESCRIPTION
Resolve dependencies from the AKSW repository over https.